### PR TITLE
Log 중복 오류 해결, Rate 설정 가능, Pending instance terminate 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 ### lambda code zip
 **/terminate-no-name-instances.zip
+**/terminate-pending-instances.zip
 **/spot-availability-tester.zip
 
 ### Credentials

--- a/spot-availability-tester/aws/IaC-cloudwatchlogs/main.tf
+++ b/spot-availability-tester/aws/IaC-cloudwatchlogs/main.tf
@@ -1,10 +1,5 @@
 resource "aws_cloudwatch_log_group" "spot_availability_tester_log_group" {
-  name              = var.spot_availability_tester_log_group_name
-  retention_in_days = 90
-}
-
-resource "aws_cloudwatch_log_group" "terminate_no_name_instance_log_group" {
-  name              = var.terminate_no_name_instance_log_group_name
+  name              = var.log_group_name
   retention_in_days = 90
 }
 

--- a/spot-availability-tester/aws/IaC-cloudwatchlogs/var.tf
+++ b/spot-availability-tester/aws/IaC-cloudwatchlogs/var.tf
@@ -13,12 +13,7 @@ variable "prefix" {
   default = ""
 }
 
-variable "spot_availability_tester_log_group_name" {
-  type = string
-  default = ""
-}
-
-variable "terminate_no_name_instance_log_group_name" {
+variable "log_group_name" {
   type = string
   default = ""
 }

--- a/spot-availability-tester/aws/IaC/main.tf
+++ b/spot-availability-tester/aws/IaC/main.tf
@@ -10,8 +10,16 @@ module "terminate-no-name-instances" {
   source = "./terminate-no-name-instance"
   prefix = var.prefix
   lambda_role_arn = aws_iam_role.terminate-no-name-instance-lambda-role.arn
-  log_group_name = var.terminate_no_name_instance_log_group_name
+  log_group_name = var.log_group_name
   log_stream_name = var.terminate_log_stream_name
+}
+
+module "terminate-pending-instances" {
+  source = "./terminate-pending-instance"
+  prefix = var.prefix
+  lambda_role_arn = aws_iam_role.terminate-pending-instance-lambda-role.arn
+  log_group_name = var.log_group_name
+  log_stream_name = var.pending_log_stream_name
 }
 
 module "spot-availability-tester" {
@@ -24,6 +32,7 @@ module "spot-availability-tester" {
   security_group_id = module.vpc.security_group_id
   instance_types = var.instance_types
   instance_types_az = var.instance_types_az
-  log_group_name = var.spot_availability_tester_log_group_name
+  log_group_name = var.log_group_name
   log_stream_name = var.spot_log_stream_name
+  lambda_rate = var.lambda_rate
 }

--- a/spot-availability-tester/aws/IaC/role.tf
+++ b/spot-availability-tester/aws/IaC/role.tf
@@ -51,3 +51,30 @@ resource "aws_iam_role_policy_attachment" "terminate-no-name-instance-lambda_EC2
   role       = aws_iam_role.terminate-no-name-instance-lambda-role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
 }
+
+resource "aws_iam_role" "terminate-pending-instance-lambda-role" {
+  name = "${var.prefix}-terminate-pending-instances-${var.region}-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Sid    = ""
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "terminate-pending-instance-lambda_basic_policy" {
+  role       = aws_iam_role.terminate-pending-instance-lambda-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "terminate-pending-instance-lambda_EC2_policy" {
+  role       = aws_iam_role.terminate-pending-instance-lambda-role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+}

--- a/spot-availability-tester/aws/IaC/spot-availability-tester/lambda.tf
+++ b/spot-availability-tester/aws/IaC/spot-availability-tester/lambda.tf
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "lambda" {
 resource "aws_cloudwatch_event_rule" "eventbridge-rule" {
   count               = length(var.instance_types)
   name                = "${var.prefix}-${var.instance_types[count.index]}-${var.instance_types_az[count.index]}-rule"
-  schedule_expression = "rate(1 minute)"
+  schedule_expression = var.lambda_rate
   depends_on          = [aws_lambda_function.lambda]
 }
 

--- a/spot-availability-tester/aws/IaC/spot-availability-tester/var.tf
+++ b/spot-availability-tester/aws/IaC/spot-availability-tester/var.tf
@@ -8,3 +8,4 @@ variable "log_group_name" {}
 variable "log_stream_name" {}
 variable "instance_types" {}
 variable "instance_types_az" {}
+variable "lambda_rate" {}

--- a/spot-availability-tester/aws/IaC/terminate-no-name-instance/lambda.tf
+++ b/spot-availability-tester/aws/IaC/terminate-no-name-instance/lambda.tf
@@ -23,14 +23,14 @@ resource "aws_lambda_function" "lambda" {
 
 # EventBridge Rule
 resource "aws_cloudwatch_event_rule" "eventbridge-rule" {
-  name                = "one-minute-terminate-no-name-instances"
+  name                = "${var.prefix}-one-minute-terminate-no-name-instances"
   schedule_expression = "rate(1 minute)"
 }
 
 # Target for EventBridge to trigger Lambda
 resource "aws_cloudwatch_event_target" "eventbridge-target" {
   rule      = aws_cloudwatch_event_rule.eventbridge-rule.name
-  target_id = "one-minute-terminate-no-name-instances"
+  target_id = "${var.prefix}-one-minute-terminate-no-name-instances"
   arn       = aws_lambda_function.lambda.arn
 }
 

--- a/spot-availability-tester/aws/IaC/terminate-no-name-instances.py
+++ b/spot-availability-tester/aws/IaC/terminate-no-name-instances.py
@@ -27,7 +27,7 @@ def lambda_handler(event, context):
     for reservation in response['Reservations']:
         for instance in reservation['Instances']:
             name_tags = [tag['Value'] for tag in instance.get('Tags', []) if tag['Key'] == 'Name']
-            if ((not name_tags or not name_tags[0]) and instance['State']['Name'] != "terminated"):
+            if ((not name_tags or not name_tags[0]) and instance['State']['Name'] != "terminated" and instance['State']['Name'] != "shutting-down"):
                 instances_to_terminate.append(instance['InstanceId'])
                 launch_time = (instance['LaunchTime']).timestamp()
                 terminate_time = time.time()
@@ -36,8 +36,9 @@ def lambda_handler(event, context):
                     "TerminateTime": terminate_time,
                     "BillingTime": terminate_time - launch_time,
                     "InstanceId": instance['InstanceId'],
+                    "InstanceState": instance['State']['Name'],
                     "InstanceType": instance['InstanceType'],
-                    "AvailabilityZone": instance['Placement']['AvailabilityZone']
+                    "AvailabilityZone": instance['Placement']['AvailabilityZone'],
                 }
                 instances_logs.append(tmp_data)
 

--- a/spot-availability-tester/aws/IaC/terminate-pending-instance/data.tf
+++ b/spot-availability-tester/aws/IaC/terminate-pending-instance/data.tf
@@ -1,0 +1,5 @@
+data "archive_file" "lambda_source_code" {
+  type        = "zip"
+  source_file = "terminate-pending-instances.py"
+  output_path = "terminate-pending-instances.zip"
+}

--- a/spot-availability-tester/aws/IaC/terminate-pending-instance/lambda.tf
+++ b/spot-availability-tester/aws/IaC/terminate-pending-instance/lambda.tf
@@ -23,7 +23,7 @@ resource "aws_lambda_function" "lambda" {
 
 # EventBridge Rule
 resource "aws_cloudwatch_event_rule" "eventbridge-rule" {
-  name                = "terminate-pending-instances"
+  name                = "${var.prefix}-terminate-pending-instances"
   event_pattern = jsonencode({
     source = ["aws.ec2"],
     detail-type = ["EC2 Instance State-change Notification"],
@@ -36,7 +36,7 @@ resource "aws_cloudwatch_event_rule" "eventbridge-rule" {
 # Target for EventBridge to trigger Lambda
 resource "aws_cloudwatch_event_target" "eventbridge-target" {
   rule      = aws_cloudwatch_event_rule.eventbridge-rule.name
-  target_id = "terminate-pending-instances"
+  target_id = "${var.prefix}-terminate-pending-instances"
   arn       = aws_lambda_function.lambda.arn
 }
 

--- a/spot-availability-tester/aws/IaC/terminate-pending-instance/lambda.tf
+++ b/spot-availability-tester/aws/IaC/terminate-pending-instance/lambda.tf
@@ -1,0 +1,49 @@
+resource "aws_cloudwatch_log_group" "lambda-cloudwatch-log-group" {
+  name = "/aws/lambda/${aws_lambda_function.lambda.function_name}"
+  retention_in_days = 30
+}
+
+resource "aws_lambda_function" "lambda" {
+  function_name = "${var.prefix}-terminate-pending-instances"
+  architectures = ["x86_64"]
+  memory_size   = 128
+  timeout       = 30
+  runtime       = "python3.11"
+  handler       = "terminate-pending-instances.lambda_handler"
+  filename      = "terminate-pending-instances.zip"
+  role          = var.lambda_role_arn
+
+  environment {
+    variables = {
+      LOG_GROUP_NAME    = var.log_group_name,
+      LOG_STREAM_NAME   = var.log_stream_name
+    }
+  }
+}
+
+# EventBridge Rule
+resource "aws_cloudwatch_event_rule" "eventbridge-rule" {
+  name                = "terminate-pending-instances"
+  event_pattern = jsonencode({
+    source = ["aws.ec2"],
+    detail-type = ["EC2 Instance State-change Notification"],
+    detail = {
+      state = ["pending"]
+    }
+  })
+}
+
+# Target for EventBridge to trigger Lambda
+resource "aws_cloudwatch_event_target" "eventbridge-target" {
+  rule      = aws_cloudwatch_event_rule.eventbridge-rule.name
+  target_id = "terminate-pending-instances"
+  arn       = aws_lambda_function.lambda.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_rw_fallout_retry_step_deletion_lambda" {
+  statement_id = "AllowExecutionFromCloudWatch"
+  action = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda.function_name
+  principal = "events.amazonaws.com"
+  source_arn = aws_cloudwatch_event_rule.eventbridge-rule.arn
+}

--- a/spot-availability-tester/aws/IaC/terminate-pending-instance/var.tf
+++ b/spot-availability-tester/aws/IaC/terminate-pending-instance/var.tf
@@ -1,0 +1,4 @@
+variable "prefix" {}
+variable "lambda_role_arn" {}
+variable "log_group_name" {}
+variable "log_stream_name" {}

--- a/spot-availability-tester/aws/IaC/terminate-pending-instances.py
+++ b/spot-availability-tester/aws/IaC/terminate-pending-instances.py
@@ -1,0 +1,33 @@
+import boto3
+import os
+import time
+import json
+
+LOG_GROUP_NAME = os.environ['LOG_GROUP_NAME']
+LOG_STREAM_NAME = os.environ['LOG_STREAM_NAME']
+
+ec2 = boto3.client('ec2')
+logs_client = boto3.client('logs')
+
+def create_log_event(result):
+    log_event = {
+        'timestamp': int(time.time() * 1000),
+        'message': result
+    }
+    logs_client.put_log_events(
+        logGroupName=LOG_GROUP_NAME, logStreamName=LOG_STREAM_NAME, logEvents=[log_event])
+
+def lambda_handler(event, context):
+    instances_to_terminate = []
+    instances_to_terminate.append(event['detail']['instance-id'])
+
+    log_data = {
+        "Timestamp": time.time(),
+        "InstanceId": event['detail']['instance-id'],
+        "InstanceState": event['detail']['state'],
+        "Region": event['region'],
+    }
+    create_log_event(json.dumps(log_data))
+
+    ec2.terminate_instances(InstanceIds=instances_to_terminate)
+    print(f"Terminated instances: {event['detail']['instance-id']}")

--- a/spot-availability-tester/aws/IaC/var.tf
+++ b/spot-availability-tester/aws/IaC/var.tf
@@ -14,12 +14,7 @@ variable "prefix" {
 }
 
 # must define exist cloudwatch log (from IaC-cloudwatch)
-variable "spot_availability_tester_log_group_name" {
-  type = string
-  default = ""
-}
-
-variable "terminate_no_name_instance_log_group_name" {
+variable "log_group_name" {
   type = string
   default = ""
 }
@@ -34,6 +29,11 @@ variable "terminate_log_stream_name" {
   default = ""
 }
 
+variable "pending_log_stream_name" {
+  type = string
+  default = ""
+}
+
 variable "instance_types" {
   type = list(string)
   default = []
@@ -42,4 +42,9 @@ variable "instance_types" {
 variable "instance_types_az" {
   type = list(string)
   default = []
+}
+
+variable "lambda_rate" {
+  type = string
+  default = ""
 }

--- a/spot-availability-tester/aws/check_quota.py
+++ b/spot-availability-tester/aws/check_quota.py
@@ -1,0 +1,25 @@
+import boto3
+import variables
+
+awscli_profile = variables.awscli_profile
+
+with open('regions.txt', 'r', encoding='utf-8') as file:
+    regions = [line.strip() for line in file.readlines()]
+
+for region in regions:
+    session = boto3.Session(profile_name=awscli_profile, region_name=region)
+    quota_client = session.client('service-quotas')
+
+    response = quota_client.get_service_quota(
+        ServiceCode='ec2',
+        #standard
+        # QuotaCode='L-34B43A08'
+        #g,vt
+        # QuotaCode='L-3819A6DF'
+        #inf
+        # QuotaCode='L-B5D1601B'
+        #all f
+        QuotaCode='L-88CF9481'
+    )
+
+    print(f"Region: {region}, {response['Quota']['Value']}")

--- a/spot-availability-tester/aws/create_log_group.py
+++ b/spot-availability-tester/aws/create_log_group.py
@@ -20,8 +20,7 @@ def run_command(command):
 def main():
     awscli_profile = variables.awscli_profile
     prefix = variables.prefix
-    spot_availability_tester_log_group_name = f"{prefix}-spot-availability-tester-log"
-    terminate_no_name_instance_log_group_name = f"{prefix}-terminate-no-name-instance-log"
+    log_group_name = f"{prefix}-spot-availability-tester-log"
 
     tf_project_dir = "./IaC-cloudwatchlogs"
     with open('regions.txt', 'r', encoding='utf-8') as file:
@@ -31,7 +30,7 @@ def main():
     for region in regions:
         run_command(["terraform", "workspace", "new", f"{region}"])
         run_command(["terraform", "init"])
-        run_command(["terraform", "apply", "--auto-approve", "--var", f"region={region}", "--var", f"prefix={prefix}","--var", f"awscli_profile={awscli_profile}", "--var", f"spot_availability_tester_log_group_name={spot_availability_tester_log_group_name}", "--var", f"terminate_no_name_instance_log_group_name={terminate_no_name_instance_log_group_name}"])
+        run_command(["terraform", "apply", "--auto-approve", "--var", f"region={region}", "--var", f"prefix={prefix}","--var", f"awscli_profile={awscli_profile}", "--var", f"log_group_name={log_group_name}"])
 
 
 if __name__ == "__main__":

--- a/spot-availability-tester/aws/create_tester.py
+++ b/spot-availability-tester/aws/create_tester.py
@@ -36,10 +36,11 @@ def main():
     # Change this
     awscli_profile = variables.awscli_profile
     prefix = variables.prefix
-    spot_availability_tester_log_group_name = f"{prefix}-spot-availability-tester-log"
-    terminate_no_name_instance_log_group_name = f"{prefix}-terminate-no-name-instance-log"
+    log_group_name = f"{prefix}-spot-availability-tester-log"
     spot_log_stream_name = f"{variables.log_stream_name}-spot"
     terminate_log_stream_name = f"{variables.log_stream_name}-terminate"
+    pending_log_stream_name = f"{variables.log_stream_name}-pending"
+    spawn_rate = "rate(1 minute)" if variables.spawn_rate == 1 else f"rate({spawn_rate} minutes)"
 
     tf_project_dir = "./IaC"
     with open('regions.txt', 'r', encoding='utf-8') as file:
@@ -51,8 +52,9 @@ def main():
         session = boto3.Session(profile_name=awscli_profile, region_name=region)
         logs_client = session.client('logs')
 
-        create_log_stream(spot_availability_tester_log_group_name, spot_log_stream_name, logs_client)
-        create_log_stream(terminate_no_name_instance_log_group_name, terminate_log_stream_name, logs_client)
+        create_log_stream(log_group_name, spot_log_stream_name, logs_client)
+        create_log_stream(log_group_name, terminate_log_stream_name, logs_client)
+        create_log_stream(log_group_name, pending_log_stream_name, logs_client)
 
         tmp_data = pd.read_csv(f'./test_data/{region}.csv')
         instance_type_data[f"{region}"] = ",".join(f'"{item}"' for item in tmp_data['InstanceType'].tolist())
@@ -62,7 +64,7 @@ def main():
     for region in regions:
         run_command(["terraform", "workspace", "new", f"{region}"])
         run_command(["terraform", "init"])
-        run_command(["terraform", "apply", "--parallelism=150", "--auto-approve", "--var", f"region={region}", "--var", f"prefix={prefix}","--var", f"awscli_profile={awscli_profile}", "--var", f"spot_availability_tester_log_group_name={spot_availability_tester_log_group_name}", "--var", f"terminate_no_name_instance_log_group_name={terminate_no_name_instance_log_group_name}", "--var", f"spot_log_stream_name={spot_log_stream_name}", "--var", f"terminate_log_stream_name={terminate_log_stream_name}", "--var", f"instance_types=[{instance_type_data[region]}]", "--var", f"instance_types_az=[{availability_zone_data[region]}]"])
+        run_command(["terraform", "apply", "--parallelism=150", "--auto-approve", "--var", f"region={region}", "--var", f"prefix={prefix}","--var", f"awscli_profile={awscli_profile}", "--var", f"log_group_name={log_group_name}", "--var", f"spot_log_stream_name={spot_log_stream_name}", "--var", f"terminate_log_stream_name={terminate_log_stream_name}", "--var", f"pending_log_stream_name={pending_log_stream_name}", "--var", f"instance_types=[{instance_type_data[region]}]", "--var", f"instance_types_az=[{availability_zone_data[region]}]", "--var", f"lambda_rate={spawn_rate}"])
 
 
 if __name__ == "__main__":

--- a/spot-availability-tester/aws/create_tester.py
+++ b/spot-availability-tester/aws/create_tester.py
@@ -40,7 +40,7 @@ def main():
     spot_log_stream_name = f"{variables.log_stream_name}-spot"
     terminate_log_stream_name = f"{variables.log_stream_name}-terminate"
     pending_log_stream_name = f"{variables.log_stream_name}-pending"
-    spawn_rate = "rate(1 minute)" if variables.spawn_rate == 1 else f"rate({spawn_rate} minutes)"
+    spawn_rate = "rate(1 minute)" if variables.spawn_rate == 1 else f"rate({variables.spawn_rate} minutes)"
 
     tf_project_dir = "./IaC"
     with open('regions.txt', 'r', encoding='utf-8') as file:

--- a/spot-availability-tester/aws/delete_log_group.py
+++ b/spot-availability-tester/aws/delete_log_group.py
@@ -20,8 +20,7 @@ def run_command(command):
 def main():
     awscli_profile = variables.awscli_profile
     prefix = variables.prefix
-    spot_availability_tester_log_group_name = f"{prefix}-spot-availability-tester-log"
-    terminate_no_name_instance_log_group_name = f"{prefix}-terminate-no-name-instance-log"
+    log_group_name = f"{prefix}-spot-availability-tester-log"
 
     tf_project_dir = "./IaC-cloudwatchlogs"
     with open('regions.txt', 'r', encoding='utf-8') as file:
@@ -31,7 +30,7 @@ def main():
 
     for region in regions:
         run_command(["terraform", "workspace", "select", "-or-create", f"{region}"])
-        run_command(["terraform", "destroy", "--auto-approve", "--var", f"region={region}", "--var", f"prefix={prefix}","--var", f"awscli_profile={awscli_profile}", "--var", f"spot_availability_tester_log_group_name={spot_availability_tester_log_group_name}", "--var", f"terminate_no_name_instance_log_group_name={terminate_no_name_instance_log_group_name}"])
+        run_command(["terraform", "destroy", "--auto-approve", "--var", f"region={region}", "--var", f"prefix={prefix}","--var", f"awscli_profile={awscli_profile}", "--var", f"log_group_name={log_group_name}"])
         run_command(["terraform", "workspace", "select", "default"])
         run_command(["terraform", "workspace", "delete", f"{region}"])
 

--- a/spot-availability-tester/aws/delete_tester.py
+++ b/spot-availability-tester/aws/delete_tester.py
@@ -36,7 +36,7 @@ def main():
     spot_log_stream_name = f"{variables.log_stream_name}-spot"
     terminate_log_stream_name = f"{variables.log_stream_name}-terminate"
     pending_log_stream_name = f"{variables.log_stream_name}-pending"
-    spawn_rate = "rate(1 minute)" if variables.spawn_rate == 1 else f"rate({spawn_rate} minutes)"
+    spawn_rate = "rate(1 minute)" if variables.spawn_rate == 1 else f"rate({variables.spawn_rate} minutes)"
 
     tf_project_dir = "./IaC"
     with open('regions.txt', 'r', encoding='utf-8') as file:

--- a/spot-availability-tester/aws/delete_tester.py
+++ b/spot-availability-tester/aws/delete_tester.py
@@ -32,10 +32,11 @@ def delete_cloudwatch_log_group(log_group_name, logs_client):
 def main():
     awscli_profile = variables.awscli_profile
     prefix = variables.prefix
-    spot_availability_tester_log_group_name = f"{prefix}-spot-availability-tester-log"
-    terminate_no_name_instance_log_group_name = f"{prefix}-terminate-no-name-instance-log"
+    log_group_name = f"{prefix}-spot-availability-tester-log"
     spot_log_stream_name = f"{variables.log_stream_name}-spot"
     terminate_log_stream_name = f"{variables.log_stream_name}-terminate"
+    pending_log_stream_name = f"{variables.log_stream_name}-pending"
+    spawn_rate = "rate(1 minute)" if variables.spawn_rate == 1 else f"rate({spawn_rate} minutes)"
 
     tf_project_dir = "./IaC"
     with open('regions.txt', 'r', encoding='utf-8') as file:
@@ -54,7 +55,7 @@ def main():
         boto3_session = boto3.Session(profile_name=awscli_profile, region_name=region)
         logs_client = boto3_session.client('logs')
         run_command(["terraform", "workspace", "select", "-or-create", f"{region}"])
-        run_command(["terraform", "destroy", "--parallelism=150", "--target=module.spot-availability-tester", "--auto-approve", "--var", f"region={region}", "--var", f"prefix={prefix}","--var", f"awscli_profile={awscli_profile}", "--var", f"spot_availability_tester_log_group_name={spot_availability_tester_log_group_name}", "--var", f"terminate_no_name_instance_log_group_name={terminate_no_name_instance_log_group_name}", "--var", f"spot_log_stream_name={spot_log_stream_name}", "--var", f"terminate_log_stream_name={terminate_log_stream_name}", "--var", f"instance_types=[{instance_type_data[region]}]", "--var", f"instance_types_az=[{availability_zone_data[region]}]"])
+        run_command(["terraform", "destroy", "--parallelism=150", "--target=module.spot-availability-tester", "--auto-approve", "--var", f"region={region}", "--var", f"prefix={prefix}","--var", f"awscli_profile={awscli_profile}", "--var", f"log_group_name={log_group_name}", "--var", f"spot_log_stream_name={spot_log_stream_name}", "--var", f"terminate_log_stream_name={terminate_log_stream_name}", "--var", f"pending_log_stream_name={pending_log_stream_name}", "--var", f"instance_types=[{instance_type_data[region]}]", "--var", f"instance_types_az=[{availability_zone_data[region]}]", "--var", f"lambda_rate={spawn_rate}"])
 
     print("Wait for terminate all of instances...")
     time.sleep(150)
@@ -64,7 +65,7 @@ def main():
         boto3_session = boto3.Session(profile_name=awscli_profile, region_name=region)
         logs_client = boto3_session.client('logs')
         run_command(["terraform", "workspace", "select", "-or-create", f"{region}"])
-        run_command(["terraform", "destroy", "--parallelism=150", "--auto-approve", "--var", f"region={region}", "--var", f"prefix={prefix}","--var", f"awscli_profile={awscli_profile}", "--var", f"spot_availability_tester_log_group_name={spot_availability_tester_log_group_name}", "--var", f"terminate_no_name_instance_log_group_name={terminate_no_name_instance_log_group_name}", "--var", f"spot_log_stream_name={spot_log_stream_name}", "--var", f"terminate_log_stream_name={terminate_log_stream_name}", "--var", f"instance_types=[{instance_type_data[region]}]", "--var", f"instance_types_az=[{availability_zone_data[region]}]"])
+        run_command(["terraform", "destroy", "--parallelism=150", "--auto-approve", "--var", f"region={region}", "--var", f"prefix={prefix}","--var", f"awscli_profile={awscli_profile}", "--var", f"log_group_name={log_group_name}", "--var", f"spot_log_stream_name={spot_log_stream_name}", "--var", f"terminate_log_stream_name={terminate_log_stream_name}", "--var", f"pending_log_stream_name={pending_log_stream_name}", "--var", f"instance_types=[{instance_type_data[region]}]", "--var", f"instance_types_az=[{availability_zone_data[region]}]", "--var", f"lambda_rate={spawn_rate}"])
         run_command(["terraform", "workspace", "select", "default"])
         run_command(["terraform", "workspace", "delete", f"{region}"])
         delete_cloudwatch_log_group(f"/aws/lambda/{prefix}-spot-availability-tester", logs_client)

--- a/spot-availability-tester/aws/regions.txt.sample
+++ b/spot-availability-tester/aws/regions.txt.sample
@@ -1,2 +1,17 @@
+ap-northeast-1
 ap-northeast-2
+ap-northeast-3
+ap-south-1
+ap-southeast-1
+ap-southeast-2
+ca-central-1
+eu-central-1
+eu-north-1
+eu-west-1
+eu-west-2
+eu-west-3
+sa-east-1
 us-east-1
+us-east-2
+us-west-1
+us-west-2

--- a/spot-availability-tester/aws/variables.py.sample
+++ b/spot-availability-tester/aws/variables.py.sample
@@ -1,3 +1,4 @@
 awscli_profile = ""
 prefix = ""
 log_stream_name = ""
+spawn_rate = 1


### PR DESCRIPTION
- #18 issue가 해결되었습니다. (shutting-down state instance를 다시 terminate 하는 이슈)
- rate를 variables.py에서 설정할 수 있도록 추가하였습니다.
- pending instance terminate 기능을 추가하였습니다.
  - EventBridge의 EC2 State Notification을 활용해 pending instance는 그 즉시 terminate하는 lambda function으로 전달되게끔 추가하였습니다.
  - pending 상태에서는 비용이 청구되지 않기에 더 많은 비용을 절감할 것으로 기대합니다.
  - 기존 1분마다 name tag가 붙지 않은 lambda function도 같이 동작하여 실패하는 경우를 cover합니다.