### PR TITLE
Fix: pending-evaulation

### DIFF
--- a/spot-availability-tester/aws/IaC/spot-availability-tester-ec2.py
+++ b/spot-availability-tester/aws/IaC/spot-availability-tester-ec2.py
@@ -3,6 +3,8 @@ import os
 import time
 import json
 import base64
+import pytz
+import datetime
 
 ec2 = boto3.client('ec2')
 logs_client = boto3.client('logs')
@@ -87,7 +89,8 @@ def test_spot_instance_available(instance_type, availability_zone, ddd_request_t
     user_data = """#!/bin/bash
     shutdown -h now"""
     user_data_encoded = base64.b64encode(user_data.encode()).decode()
-
+    stop_time = datetime.datetime.now() + datetime.timedelta(minutes=2)
+    stop_time = stop_time.astimezone(pytz.UTC)
     spot_request = ec2.request_spot_instances(
         InstanceCount=1,
         Type='one-time',
@@ -101,6 +104,7 @@ def test_spot_instance_available(instance_type, availability_zone, ddd_request_t
             },
             'UserData': user_data_encoded
         },
+        ValidUntil=stop_time,
     )
 
     create_time = spot_request['SpotInstanceRequests'][0]['CreateTime']


### PR DESCRIPTION
기존 DDD 실험 람다 코드에 스팟 요청의 지속시간을 추가하였습니다. 규민님 실험 (https://github.com/ddps-lab/research-issues/issues/587#issuecomment-2368873426) 에서 Running 단계까지 1분 미만으로 소요되는 것을 확인하였기에 요청 지속시간을 2분으로 설정하였습니다.

람다가 60초동안 실행되기 때문에 지속시간이 만료되어 취소되는 경우를 감지할 수 없습니다. 만일 pending-evalutaion 단계에서 지속시간 만료로 인해 취소가 됐다면, 해당 요청에 대한 로그가 남지 않는 것으로써 실패했다고 확인하면 될 것 같습니다.